### PR TITLE
j57ayzbwbsmg4c6r7qqt5ecdy5819ga0: Sprint 1.3a - HTTP router scaffold with health endpoint

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,0 +1,65 @@
+import { httpRouter, httpActionGeneric } from 'convex/server'
+
+const http = httpRouter()
+
+/**
+ * CORS configuration for web dashboard
+ * Allows requests from the dashboard origin
+ */
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*', // TODO: Restrict to dashboard domain in production
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Max-Age': '86400',
+}
+
+/**
+ * Helper to add CORS headers to response
+ */
+function withCors(response: Response): Response {
+  Object.entries(corsHeaders).forEach(([key, value]) => {
+    response.headers.set(key, value)
+  })
+  return response
+}
+
+/**
+ * Health check endpoint
+ * GET /api/health
+ * Returns: { status: "ok" }
+ */
+http.route({
+  path: '/api/health',
+  method: 'GET',
+  handler: httpActionGeneric(async () => {
+    return withCors(
+      new Response(
+        JSON.stringify({ status: 'ok' }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    )
+  }),
+})
+
+/**
+ * OPTIONS handler for CORS preflight requests
+ */
+http.route({
+  path: '/api/health',
+  method: 'OPTIONS',
+  handler: httpActionGeneric(async () => {
+    return withCors(
+      new Response(null, {
+        status: 204,
+      })
+    )
+  }),
+})
+
+// Export the HTTP router
+export default http


### PR DESCRIPTION
**Task:** j57ayzbwbsmg4c6r7qqt5ecdy5819ga0

**Sprint:** 1.3a - HTTP Actions - REST API Scaffold

## Summary
Created convex/http.ts with HTTP router scaffold and health check endpoint.

## Changes
- Created `convex/http.ts` with:
  - HTTP router using `httpRouter()` from convex/server
  - CORS configuration for web dashboard origin
  - `GET /api/health` endpoint returning `{ status: 'ok' }`
  - `OPTIONS /api/health` for CORS preflight
  - Helper function `withCors()` to add CORS headers

## Implementation Details
- Used `httpActionGeneric` for route handlers (correct Convex API)
- CORS headers configured with wildcard origin (TODO: restrict in production)
- Health endpoint returns 200 status with JSON response
- OPTIONS handler returns 204 for preflight requests

## Testing
```bash
✓ pnpm test          # 10 tests passing
✓ pnpm typecheck     # No errors
✓ pnpm lint          # 0 errors, 14 warnings (expected)
```

## Acceptance Criteria
✓ convex/http.ts exports valid httpRouter  
✓ CORS headers configured for web dashboard  
✓ GET /api/health returns 200 { status: 'ok' }  
✓ Endpoints will be accessible at `<deployment>.convex.site/api/*`  

## Next Steps
- Deploy to Convex to test endpoint accessibility
- Add additional API endpoints (board, tasks, workload)
- Restrict CORS to specific dashboard domain in production