### PR TITLE
j5775p9zdwbnkwpdzvamjvd375819m31: Sprint 1.3b - Environment-based CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,17 @@
 # Convex
 VITE_CONVEX_URL=https://your-deployment.convex.cloud
 
+# CORS Configuration
+# Comma-separated list of allowed origins for API requests
+# Leave empty or set to '*' for development (allows all origins)
+# Set to specific domains in production for security
+# Example: ALLOWED_ORIGINS=https://dashboard.example.com,https://app.example.com
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
 # Better Auth (to be configured in later sprint)
 # AUTH_SECRET=your-secret-key
 # GITHUB_CLIENT_ID=your-github-oauth-client-id
 # GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
 
 # App URL
-# PUBLIC_APP_URL=http://localhost:3000
+PUBLIC_APP_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Edit `.env.local` with your configuration:
 # Convex
 CONVEX_URL=https://your-project.convex.cloud
 
+# CORS Configuration (optional)
+# Comma-separated list of allowed origins for API requests
+# Leave empty or set to '*' for development (allows all origins)
+# Set to specific domains in production for security
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
 # Better Auth
 AUTH_SECRET=your-secret-key
 GITHUB_CLIENT_ID=your-github-oauth-client-id
@@ -66,6 +72,14 @@ GITHUB_CLIENT_SECRET=your-github-oauth-client-secret
 # App URL
 PUBLIC_APP_URL=http://localhost:3000
 ```
+
+**CORS Security:**
+
+The API uses environment-based CORS configuration for security:
+
+- **Development:** Set `ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173` or leave empty to allow all origins
+- **Production:** Set `ALLOWED_ORIGINS=https://yourdomain.com` to restrict API access to your dashboard domain
+- Multiple origins supported: `ALLOWED_ORIGINS=https://app.example.com,https://dashboard.example.com`
 
 4. **Run the development server**
 


### PR DESCRIPTION
**Task:** j5775p9zdwbnkwpdzvamjvd375819m31

**Sprint:** 1.3b - Configure CORS headers for web dashboard

## Summary
Implemented environment-based CORS configuration for enhanced security, replacing hardcoded wildcard CORS with configurable allowed origins.

## Changes

### convex/http.ts
- Replaced hardcoded wildcard (`*`) CORS with environment-based configuration
- Added `getAllowedOrigins()` function to read from `ALLOWED_ORIGINS` env var
- Updated `withCors()` helper to support origin-specific responses
- Added `Vary: Origin` header for proper caching when using specific origins
- Falls back to wildcard (`*`) for development when not configured

### .env.example
- Added `ALLOWED_ORIGINS` configuration with examples
- Documented comma-separated origins support
- Included default development origins (localhost:3000, localhost:5173)
- Uncommented `PUBLIC_APP_URL` for clarity

### README.md
- Added **CORS Security** section in environment variables setup
- Documented development vs production configuration
- Provided examples for single and multiple origins
- Explained security best practices

## Implementation Details
- Supports comma-separated list of allowed origins
- Origin-specific responses when not using wildcard
- Proper `Vary` header for cache control
- Backward compatible (defaults to `*` if not configured)

## Security
- **Development:** Allows all origins or localhost by default
- **Production:** Restricts to configured domains only
- Prevents unauthorized cross-origin API access

## Testing
```bash
✓ pnpm test          # 10 tests passing
✓ pnpm typecheck     # No errors
✓ pnpm lint          # 0 errors, 14 pre-existing warnings
```

## Acceptance Criteria
✓ CORS headers configurable via environment variables  
✓ Supports development and production modes  
✓ Documented in README and .env.example  
✓ Backward compatible with existing setup  
✓ All tests passing  

## Example Usage

**Development:**
```env
ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
```

**Production:**
```env
ALLOWED_ORIGINS=https://dashboard.example.com
```

**Multiple Domains:**
```env
ALLOWED_ORIGINS=https://app.example.com,https://dashboard.example.com
```