### PR TITLE
fix(e2e): activity-timeline strict mode locator

### DIFF
--- a/e2e/tests/sprint4-validation.spec.ts
+++ b/e2e/tests/sprint4-validation.spec.ts
@@ -325,7 +325,7 @@ test.describe('Sprint 4: Activity Log (4.4a-c)', () => {
     const timeline = page.locator('[data-testid="activity-timeline"]')
     await expect(timeline).toBeVisible()
 
-    const heading = timeline.getByText('Activity')
+    const heading = timeline.getByRole('heading', { name: 'Activity' })
     await expect(heading).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary
- make the activity timeline heading assertion unambiguous in Sprint 4 E2E tests
- replace text locator with a role-based heading locator scoped to the timeline container

## Validation
- pnpm exec playwright test --project=desktop-chromium e2e/tests/sprint4-validation.spec.ts 2>&1 | tail -20
