### PR TITLE
fix: remove TanStack logo — replace with Agent Dashboard branding

### DIFF
--- a/src/__tests__/components/Header.test.tsx
+++ b/src/__tests__/components/Header.test.tsx
@@ -20,12 +20,12 @@ describe('Header', () => {
     expect(header).not.toBeNull()
   })
 
-  it('should render the logo link to home', () => {
+  it('should render the Agent Dashboard branding link to home', () => {
     render(<Header />)
 
-    const logoLink = screen.getByAltText('TanStack Logo')
-    expect(logoLink).toBeDefined()
-    expect(logoLink.closest('a')?.getAttribute('href')).toBe('/')
+    const brandLink = screen.getByText('Agent Dashboard')
+    expect(brandLink).toBeDefined()
+    expect(brandLink.closest('a')?.getAttribute('href')).toBe('/')
   })
 
   it('should render the menu button with accessible label', () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/react-router'
 
 import { useState } from 'react'
-import { Home, Menu, X, LogOut } from 'lucide-react'
+import { Home, Menu, X, LogOut, Bot } from 'lucide-react'
 import { useSession, signOut } from '../lib/auth-client'
 
 export default function Header() {
@@ -29,12 +29,9 @@ export default function Header() {
           <Menu size={24} />
         </button>
         <h1 className="ml-4 text-xl font-semibold flex-1">
-          <Link to="/">
-            <img
-              src="/tanstack-word-logo-white.svg"
-              alt="TanStack Logo"
-              className="h-10"
-            />
+          <Link to="/" className="flex items-center gap-2 text-white hover:text-cyan-400 transition-colors">
+            <Bot size={22} className="text-cyan-400" />
+            <span>Agent Dashboard</span>
           </Link>
         </h1>
 


### PR DESCRIPTION
Task: j5780t3r85f36bdssew9bvts7n81dymb

## What changed
- **Header.tsx**: Replaced `<img src='/tanstack-word-logo-white.svg' alt='TanStack Logo'>` with a `<Bot>` icon (lucide-react, cyan-400) + `<span>Agent Dashboard</span>` text link
- **Header.test.tsx**: Updated the logo assertion from `getByAltText('TanStack Logo')` to `getByText('Agent Dashboard')`

## Testing
- ✅ 833 unit tests pass (42 test files)
- ✅ E2E smoke: 0 regressions vs baseline
- ✅ Verified visually via browser — header shows Bot icon + 'Agent Dashboard', no TanStack branding

## Surgical scope
Only two files touched — no layout rework, no nav changes.