### PR TITLE
security: add HTTP security headers via Nitro config [j579ng0rqt165pm4gj1721z3gs81d7qq]

### DIFF
--- a/server/middleware/security-headers.ts
+++ b/server/middleware/security-headers.ts
@@ -1,0 +1,22 @@
+import { defineEventHandler, setResponseHeaders } from 'nitro/h3'
+
+/**
+ * Nitro server middleware that applies HTTP security headers to every response.
+ *
+ * Headers applied:
+ *   - Content-Security-Policy: restricts resource origins to reduce XSS surface
+ *   - X-Frame-Options: prevents clickjacking via iframe embedding
+ *   - X-Content-Type-Options: stops MIME-type sniffing
+ *   - Referrer-Policy: controls how much referrer info is sent cross-origin
+ *   - Permissions-Policy: disables unused browser features
+ */
+export default defineEventHandler((event) => {
+  setResponseHeaders(event, {
+    'Content-Security-Policy':
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'none'",
+    'X-Frame-Options': 'DENY',
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,15 @@ import { fileURLToPath, URL } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import { nitro } from 'nitro/vite'
 
+const securityHeaders = {
+  'Content-Security-Policy':
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'none'",
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
+}
+
 const config = defineConfig({
   resolve: {
     alias: {
@@ -15,7 +24,14 @@ const config = defineConfig({
   },
   plugins: [
     devtools(),
-    nitro({ rollupConfig: { external: [/^@sentry\//] } }),
+    nitro({
+      rollupConfig: { external: [/^@sentry\//] },
+      routeRules: {
+        '/**': {
+          headers: securityHeaders,
+        },
+      },
+    }),
     // this is the plugin that enables path aliases
     viteTsConfigPaths({
       projects: ['./tsconfig.json'],


### PR DESCRIPTION
Adds CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, and Permissions-Policy headers to all routes.

## Changes

### `vite.config.ts`
Added `routeRules` to the existing `nitro()` plugin configuration covering all routes (`/**`):

```ts
routeRules: {
  '/**': {
    headers: {
      'Content-Security-Policy': "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:; frame-ancestors 'none'",
      'X-Frame-Options': 'DENY',
      'X-Content-Type-Options': 'nosniff',
      'Referrer-Policy': 'strict-origin-when-cross-origin',
      'Permissions-Policy': 'camera=(), microphone=(), geolocation=()',
    },
  },
},
```

### `server/middleware/security-headers.ts` (new)
Added a Nitro H3 server middleware event handler for runtime enforcement. This runs on every request via Nitro's auto-discovered middleware directory.

## Headers Added
| Header | Value |
|--------|-------|
| `Content-Security-Policy` | default-src self; script/style unsafe-inline; img/connect self+https |
| `X-Frame-Options` | DENY |
| `X-Content-Type-Options` | nosniff |
| `Referrer-Policy` | strict-origin-when-cross-origin |
| `Permissions-Policy` | camera=(), microphone=(), geolocation=() |

## Testing
- TypeScript: no new errors introduced (pre-existing Convex generated-types errors on baseline are unaffected)
- Test suite: no regressions (project has no test files yet)