### PR TITLE
ci: disable visual regression until app is stable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -165,6 +165,7 @@ jobs:
   # the drift is intentional (then update baselines) or a regression.
   visual-regression:
     name: Visual Regression (informational)
+    if: false  # Disabled until app is stable — re-enable when visual baseline is locked
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Never block merges — visual failures are a signal, not a gate


### PR DESCRIPTION
Disables the visual-regression CI job (was informational / continue-on-error: true already) until the app UI is stable enough to set a reliable baseline. Re-enable by removing the `if: false` condition and running `pnpm test:visual:update` to regenerate snapshots.

Task: j579pwt8tyjn0xbagd2v23hkw581drdc